### PR TITLE
Fix typo in README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Natural sort order is useful for humans. By default sorting Strings is a lot dif
 ```elixir
 def deps do
   [
-    {:natural_order, "~> 0.2.0"}
+    {:natural_order, "~> 0.3.0"}
   ]
 end
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Natural sort order is useful for humans. By default sorting Strings is a lot dif
 ```elixir
 def deps do
   [
-    {natural_order, "~> 0.2.0"}
+    {:natural_order, "~> 0.2.0"}
   ]
 end
 ```


### PR DESCRIPTION
The world's tiniest fix to make the installation instructions copy-and-pastable, and to get the latest version. 😄

(We're using this at work, by the way, and it's great! I hope to never again have to sheepishly explain why "document 11" gets sorted before "document 10." 😆)